### PR TITLE
Don't specify storefront when opening app store page

### DIFF
--- a/lib/app_review.dart
+++ b/lib/app_review.dart
@@ -25,7 +25,7 @@ class AppReview {
       final String _appID = await getiOSAppID;
       String details = '';
       final String _url =
-          'itunes.apple.com/us/app/id$_appID?mt=8&action=write-review';
+          'itunes.apple.com/app/id$_appID?mt=8&action=write-review';
       if (await canLaunch("itms-apps://")) {
         print('launching store page');
         await launch("itms-apps://" + _url);
@@ -45,7 +45,7 @@ class AppReview {
     String details = '';
     if (Platform.isIOS) {
       final String _appID = await getiOSAppID;
-      await launch('https://itunes.apple.com/us/app/id$_appID?');
+      await launch('https://itunes.apple.com/app/id$_appID?');
       details = 'Launched App Store';
     } else {
       final String _appID = await getAppID;


### PR DESCRIPTION
If no storefront is specified, App Store will use current storefront user is using without redirecting.