### PR TITLE
Upgrade Android Plugin API to v2

### DIFF
--- a/android/src/main/java/com/appleeducate/appreview/AppReviewPlugin.java
+++ b/android/src/main/java/com/appleeducate/appreview/AppReviewPlugin.java
@@ -1,5 +1,8 @@
 package com.appleeducate.appreview;
 
+import androidx.annotation.NonNull;
+
+import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
@@ -7,12 +10,19 @@ import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /** AppReviewPlugin */
-public class AppReviewPlugin implements MethodCallHandler {
+public class AppReviewPlugin implements FlutterPlugin, MethodCallHandler {
   /** Plugin registration. */
   private Registrar registrar;
 
   private Result result;
   String appPackageName = "";
+
+  public AppReviewPlugin() {
+  }
+
+  private AppReviewPlugin(Registrar registrar) {
+    this.registrar = registrar;
+  }
 
   /** Plugin registration. */
   public static void registerWith(Registrar registrar) {
@@ -22,8 +32,12 @@ public class AppReviewPlugin implements MethodCallHandler {
     //    registrar.addRequestPermissionsResultListener(simplePermissionsPlugin);
   }
 
-  private AppReviewPlugin(Registrar registrar) {
-    this.registrar = registrar;
+  @Override
+  public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
+  }
+
+  @Override
+  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
   }
 
   @Override


### PR DESCRIPTION
Although the Android Plugin is not used, using the app_review plugin crashes when running on Flutter v1.17+ in embedded form.

Upgrading the Android Plugin API to v2 fixes the problem.