### PR TITLE
Update version constraints `http: ">=0.13.5 <2.0.0"` for wider compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.3
+
+* Update version constraints `http: ">=0.13.5 <2.0.0"` for wider compatibility
+
 ## 2.1.2
 
 * Upgrading dependencies

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: app_review
 description: Request and Write Reviews and Open Store Listing for Android and iOS in Flutter.
-version: 2.1.2+1
+version: 2.1.3+1
 maintainer: Rody Davis (@rodydavis)
 homepage: https://github.com/rodydavis/plugins
 repository: https://github.com/fluttercommunity/app_review
@@ -10,7 +10,7 @@ environment:
   flutter: ^1.10.0
 
 dependencies:
-  http: ^0.13.5
+  http: ">=0.13.5 <2.0.0"
   package_info_plus: ^4.0.2
   url_launcher: ^6.1.6
   flutter:


### PR DESCRIPTION
According to many famous repo like: `package_info_plus` and test by myself, package `http` version 0.x is API compatibile with 1.x.

So we launch this PR to update version constraints `http: ">=0.13.5 <2.0.0"` for wider compatibility